### PR TITLE
feat: ChatGPTの助けで以下確認

### DIFF
--- a/gas/tiktokanalyzer.gs
+++ b/gas/tiktokanalyzer.gs
@@ -93,22 +93,33 @@ function handleInitialData(sheet, page, limit) {
 
 function handleFilteredData(sheet, filters, page, limit) {
   try {
-    const data = sheet.getDataRange().getValues();
-    const headers = data[0];
+    const lastRow = sheet.getLastRow();
+    if (lastRow < 2) {
+      return { data: [], total: 0, currentPage: page, totalPages: 0, success: true };
+    }
 
-    const filteredRows = data.slice(1).filter(row => 
-      Object.entries(filters).every(([field, filter]) => {
+    // 1. 全データを一括取得（シートアクセスは2回のみ）
+    const allValues = sheet.getDataRange().getValues();
+    const allFormulas = sheet.getDataRange().getFormulas();
+    
+    const headers = allValues[0];
+    let dataRows = allValues.slice(1);
+    let formulaRows = allFormulas.slice(1);
+
+    // 2. フィルタリング（メモリ上で完結）
+    const filteredIndices = [];
+    dataRows = dataRows.filter((row, index) => {
+      const matches = Object.entries(filters).every(([field, filter]) => {
         const colIndex = headers.indexOf(filter.field);
         if (colIndex === -1) return false;
 
         const value = row[colIndex];
         const rowValue = typeof value === 'string' ? value.trim() : value;
-        const filterValue = filter.value;
-
+        
         // 数値フィールドの場合
         if (FIELD_TYPES.NUMBER_FIELDS.includes(filter.field)) {
           const numValue = Number(rowValue);
-          const numFilter = Number(filterValue);
+          const numFilter = Number(filter.value);
           
           switch (filter.type) {
             case FILTER_TYPES.GREATER: return numValue >= numFilter;
@@ -118,37 +129,49 @@ function handleFilteredData(sheet, filters, page, limit) {
           }
         }
         
-        // その他のフィールド（文字列等）の場合
-        return String(rowValue).toLowerCase() === String(filterValue).toLowerCase();
-      })
-    );
+        // その他のフィールド
+        return String(rowValue).toLowerCase() === String(filter.value).toLowerCase();
+      });
 
-    // ソート処理
+      if (matches) {
+        filteredIndices.push(index);
+        return true;
+      }
+      return false;
+    });
+
+    // フィルタ結果に対応する数式を取得
+    formulaRows = filteredIndices.map(index => allFormulas[index + 1]);
+
+    // 3. ソート処理（メモリ上で完結）
     const sortFilter = Object.entries(filters).find(([_, filter]) => filter.type === 'sort');
     if (sortFilter) {
       const [field, filter] = sortFilter;
       const colIndex = headers.indexOf(field);
-      filteredRows.sort((a, b) => {
-        const aVal = a[colIndex];
-        const bVal = b[colIndex];
-        return filter.value === 'asc' ? aVal - bVal : bVal - aVal;
+      const sortPairs = dataRows.map((row, index) => ({
+        data: row,
+        formula: formulaRows[index],
+        value: row[colIndex]
+      }));
+
+      sortPairs.sort((a, b) => {
+        return filter.value === 'asc' ? a.value - b.value : b.value - a.value;
       });
+
+      dataRows = sortPairs.map(pair => pair.data);
+      formulaRows = sortPairs.map(pair => pair.formula);
     }
 
+    // 4. ページネーション（配列操作のみ）
     const startIndex = (page - 1) * limit;
-    const paginatedRows = filteredRows.slice(startIndex, startIndex + limit);
-    
-    // 数式の取得
-    const formulas = paginatedRows.map(row => {
-      const rowIndex = data.findIndex(r => r[2] === row[2]); // videoIdで行を特定
-      return sheet.getRange(rowIndex + 1, 1, 1, headers.length).getFormulas()[0];
-    });
+    const paginatedData = dataRows.slice(startIndex, startIndex + limit);
+    const paginatedFormulas = formulaRows.slice(startIndex, startIndex + limit);
 
     return {
-      data: formatRows(paginatedRows, formulas),
-      total: filteredRows.length,
+      data: formatRows(paginatedData, paginatedFormulas),
+      total: dataRows.length,
       currentPage: page,
-      totalPages: Math.ceil(filteredRows.length / limit),
+      totalPages: Math.ceil(dataRows.length / limit),
       success: true
     };
   } catch (error) {


### PR DESCRIPTION
シートアクセスを2回に削減（getValuesとgetFormulasのみ）
すべての処理をメモリ上で完結
行インデックスの対応付けを維持
不要な配列操作を削減