### PR TITLE
fix: 月境界でスケジューラが確実に実行されるよう改修

### DIFF
--- a/backend/functions/cloudbuild.yaml
+++ b/backend/functions/cloudbuild.yaml
@@ -71,7 +71,7 @@ steps:
           echo "スケジュールジョブ frontend-update-schedule は既に存在します。更新します。"
           gcloud scheduler jobs update http frontend-update-schedule \
             --location=asia-northeast1 \
-            --schedule="0 3 1-31/2 * *" \
+            --schedule="0 3 * * *"\
             --uri="$$FUNCTION_URL" \
             --http-method=POST \
             --time-zone="Asia/Tokyo" \

--- a/backend/functions/services/account_info/sync_account_list.py
+++ b/backend/functions/services/account_info/sync_account_list.py
@@ -55,6 +55,12 @@ def sync_account_list(request):
     logger.info(f"====== アカウントリスト同期処理開始：{start_time.isoformat()} ======")
     
     try:
+        # 実行可能かチェック
+        if not check_last_execution():
+            message = "前回の実行から36時間経過していないため、処理をスキップします"
+            logger.info(message)
+            return message, 200
+            
         result, status_code = process_account_list()
         execution_time = (datetime.now() - start_time).total_seconds()
         logger.info(f"同期処理完了: 実行時間 {execution_time}秒, 結果: {result}")
@@ -214,6 +220,53 @@ def process_account_list():
         import traceback
         print(f"詳細エラートレース: {traceback.format_exc()}")
         return str(e), 500
+
+def check_last_execution():
+    """
+    前回の実行時刻をチェックし、36時間以上経過しているか確認する
+    Returns:
+        bool: 実行可能な場合はTrue、そうでない場合はFalse
+    """
+    try:
+        query = """
+            SELECT last_run 
+            FROM scheduler_job_info 
+            WHERE job_name = 'sync_account_list'
+        """
+        result = execute_query(query)
+        
+        if not result:
+            # 初回実行の場合、レコードを作成して実行可能とする
+            insert_query = """
+                INSERT INTO scheduler_job_info (job_name, last_run)
+                VALUES ('sync_account_list', NOW())
+            """
+            execute_write_query(insert_query)
+            logger.info("初回実行のため、実行を許可します")
+            return True
+        
+        last_run = result[0]['last_run']
+        current_time = datetime.now()
+        time_diff = current_time - last_run
+        
+        # 36時間以上経過しているかチェック
+        if time_diff.total_seconds() >= 36 * 3600:
+            # last_runを更新
+            update_query = """
+                UPDATE scheduler_job_info 
+                SET last_run = NOW()
+                WHERE job_name = 'sync_account_list'
+            """
+            execute_write_query(update_query)
+            logger.info(f"前回の実行から{time_diff.total_seconds() / 3600:.1f}時間経過しているため、実行を許可します")
+            return True
+        else:
+            logger.info(f"前回の実行から{time_diff.total_seconds() / 3600:.1f}時間しか経過していないため、実行をスキップします")
+            return False
+            
+    except Exception as e:
+        logger.error(f"実行時間チェックでエラーが発生しました: {str(e)}")
+        return True  # エラーの場合は安全のため実行を許可
 
 if __name__ == "__main__":
     # ローカルテスト用

--- a/backend/functions/services/data_sync/frontend_data_update/frontend_data_update.py
+++ b/backend/functions/services/data_sync/frontend_data_update/frontend_data_update.py
@@ -376,6 +376,53 @@ def reset_cursor(processor_name, target_table):
     
     execute_write_query(query, (processor_name, target_table))
 
+def check_last_execution():
+    """
+    前回の実行時刻をチェックし、36時間以上経過しているか確認する
+    Returns:
+        bool: 実行可能な場合はTrue、そうでない場合はFalse
+    """
+    try:
+        query = """
+            SELECT last_run 
+            FROM scheduler_job_info 
+            WHERE job_name = 'frontend_data_update'
+        """
+        result = execute_query(query)
+        
+        if not result:
+            # 初回実行の場合、レコードを作成して実行可能とする
+            insert_query = """
+                INSERT INTO scheduler_job_info (job_name, last_run)
+                VALUES ('frontend_data_update', NOW())
+            """
+            execute_write_query(insert_query)
+            logger.info("初回実行のため、実行を許可します")
+            return True
+        
+        last_run = result[0]['last_run']
+        current_time = datetime.now()
+        time_diff = current_time - last_run
+        
+        # 36時間以上経過しているかチェック
+        if time_diff.total_seconds() >= 36 * 3600:
+            # last_runを更新
+            update_query = """
+                UPDATE scheduler_job_info 
+                SET last_run = NOW()
+                WHERE job_name = 'frontend_data_update'
+            """
+            execute_write_query(update_query)
+            logger.info(f"前回の実行から{time_diff.total_seconds() / 3600:.1f}時間経過しているため、実行を許可します")
+            return True
+        else:
+            logger.info(f"前回の実行から{time_diff.total_seconds() / 3600:.1f}時間しか経過していないため、実行をスキップします")
+            return False
+            
+    except Exception as e:
+        logger.error(f"実行時間チェックでエラーが発生しました: {str(e)}")
+        return True  # エラーの場合は安全のため実行を許可
+
 # Cloud Functions エントリーポイント
 @functions_framework.http
 def scheduled_job(request):
@@ -386,6 +433,15 @@ def scheduled_job(request):
     logger.info(f"定期実行開始: {start_time}")
 
     try:
+        # 実行可能かチェック
+        if not check_last_execution():
+            logger.info("前回の実行から36時間経過していないため、処理をスキップします")
+            return {
+                "status": "skipped",
+                "message": "前回の実行から36時間経過していないため、処理をスキップします",
+                "execution_time": datetime.now().isoformat()
+            }, 200
+            
         # データ更新の実行
         result = update_frontend_from_master()
         


### PR DESCRIPTION
- Cloud Schedulerの月マタギ問題に対応するため、36時間実行制約を追加
- frontend_data_update.pyとsync_account_list.pyに前回実行チェック機能を実装
- scheduler_job_infoテーブルを利用して最終実行時刻を管理
- スケジュール設定を「0 3 * * *」(毎日AM3時)に変更して日次実行を確保
- エラー発生時は安全のため実行を許可する例外処理を追加

これにより月をまたいでも実行が確実に行われ、かつ過度に頻繁な実行を防止できます。