### PR TITLE
security: cloudbuild.yamlからAPIキーを削除

### DIFF
--- a/backend/functions/flask-service/functionbuild.yaml
+++ b/backend/functions/flask-service/functionbuild.yaml
@@ -49,7 +49,7 @@ steps:
       - '--memory=2048MB'
       - '--timeout=540s'
       - '--service-account=cloudbuild@tiktok-analytics-prod-451609.iam.gserviceaccount.com'
-      - '--set-env-vars=ENVIRONMENT=production,PROJECT_ID=tiktok-analytics-prod-451609,CLOUD_STORAGE_BUCKET=tiktok-videos-storage,GEMINI_API_KEY=AIzaSyACc82TA9iWau8soy38byr6kiZ0ZQj7mYY,INSTANCE_CONNECTION_NAME=tiktok-analytics-prod-451609:asia-northeast1:tiktok-analytics-db'
+      - '--set-env-vars=ENVIRONMENT=production,PROJECT_ID=tiktok-analytics-prod-451609,CLOUD_STORAGE_BUCKET=tiktok-videos-storage,INSTANCE_CONNECTION_NAME=tiktok-analytics-prod-451609:asia-northeast1:tiktok-analytics-db'
 
 options:
   logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
セキュリティ向上のためAPIキー管理をCloud Consoleに移行