### PR TITLE
ウォッチリストのトレンド遅延取得とアカウントタイプフィルタ一時停止

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@next/third-parties": "^15.3.3",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-portal": "^1.1.5",
@@ -2244,6 +2245,164 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
@@ -2324,6 +2483,477 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-popover": {
       "version": "1.1.6",

--- a/src/app/(protected)/watchlist/accounts/page.tsx
+++ b/src/app/(protected)/watchlist/accounts/page.tsx
@@ -170,6 +170,27 @@ export default function AccountWatchlistPage() {
     loadAccounts();
   }, [userSelectedDate]);
 
+  useEffect(() => {
+    const types = Array.from(
+      new Set(
+        accounts
+          .map(item => item.account?.account_type)
+          .filter((type): type is string => Boolean(type))
+      )
+    ).sort();
+
+    setAccountTypes(prev => {
+      if (prev.length === types.length && prev.every((type, index) => type === types[index])) {
+        return prev;
+      }
+      return types;
+    });
+
+    if (selectedAccountType && !types.includes(selectedAccountType)) {
+      setSelectedAccountType(null);
+    }
+  }, [accounts, selectedAccountType]);
+
   // アカウント選択時のハンドラ
   const handleAccountSelect = (accountName: string) => {
     setSelectedAccount(accountName);
@@ -262,11 +283,10 @@ export default function AccountWatchlistPage() {
     }
   };
 
-  // // アカウントタイプ変更ハンドラ
-  // const handleAccountTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-  //   const value = e.target.value;
-  //   setSelectedAccountType(value === "all" ? null : value);
-  // };
+  const handleAccountTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    setSelectedAccountType(value === "all" ? null : value);
+  };
 
   // 指標変更ハンドラ
   const handleMetricChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -399,7 +419,7 @@ export default function AccountWatchlistPage() {
       
       {/* フィルターエリア */}
       <div className="flex gap-4 items-center mb-6">
-        {/* <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2">
           <label className="text-sm whitespace-nowrap">アカウントタイプ:</label>
           <select 
             value={selectedAccountType || "all"}
@@ -411,7 +431,7 @@ export default function AccountWatchlistPage() {
               <option key={type} value={type}>{getAccountTypeDisplayName(type)}</option>
             ))}
           </select>
-        </div> */}
+        </div>
         <div className="w-[280px]">
           <DateRangePicker
             dateRange={dateRange}

--- a/src/app/(protected)/watchlist/accounts/page.tsx
+++ b/src/app/(protected)/watchlist/accounts/page.tsx
@@ -170,26 +170,26 @@ export default function AccountWatchlistPage() {
     loadAccounts();
   }, [userSelectedDate]);
 
-  useEffect(() => {
-    const types = Array.from(
-      new Set(
-        accounts
-          .map(item => item.account?.account_type)
-          .filter((type): type is string => Boolean(type))
-      )
-    ).sort();
+  // useEffect(() => {
+  //   const types = Array.from(
+  //     new Set(
+  //       accounts
+  //         .map(item => item.account?.account_type)
+  //         .filter((type): type is string => Boolean(type))
+  //     )
+  //   ).sort();
 
-    setAccountTypes(prev => {
-      if (prev.length === types.length && prev.every((type, index) => type === types[index])) {
-        return prev;
-      }
-      return types;
-    });
+  //   setAccountTypes(prev => {
+  //     if (prev.length === types.length && prev.every((type, index) => type === types[index])) {
+  //       return prev;
+  //     }
+  //     return types;
+  //   });
 
-    if (selectedAccountType && !types.includes(selectedAccountType)) {
-      setSelectedAccountType(null);
-    }
-  }, [accounts, selectedAccountType]);
+  //   if (selectedAccountType && !types.includes(selectedAccountType)) {
+  //     setSelectedAccountType(null);
+  //   }
+  // }, [accounts, selectedAccountType]);
 
   // アカウント選択時のハンドラ
   const handleAccountSelect = (accountName: string) => {
@@ -283,10 +283,10 @@ export default function AccountWatchlistPage() {
     }
   };
 
-  const handleAccountTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
-    setSelectedAccountType(value === "all" ? null : value);
-  };
+  // const handleAccountTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  //   const value = e.target.value;
+  //   setSelectedAccountType(value === "all" ? null : value);
+  // };
 
   // 指標変更ハンドラ
   const handleMetricChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -419,7 +419,7 @@ export default function AccountWatchlistPage() {
       
       {/* フィルターエリア */}
       <div className="flex gap-4 items-center mb-6">
-        <div className="flex items-center gap-2">
+        {/* <div className="flex items-center gap-2">
           <label className="text-sm whitespace-nowrap">アカウントタイプ:</label>
           <select 
             value={selectedAccountType || "all"}
@@ -431,7 +431,7 @@ export default function AccountWatchlistPage() {
               <option key={type} value={type}>{getAccountTypeDisplayName(type)}</option>
             ))}
           </select>
-        </div>
+        </div> */}
         <div className="w-[280px]">
           <DateRangePicker
             dateRange={dateRange}

--- a/src/app/(protected)/watchlist/videos/page.tsx
+++ b/src/app/(protected)/watchlist/videos/page.tsx
@@ -101,7 +101,6 @@ export default function VideoWatchlistPage() {
   
   // 動画データ
   const [watchlistVideos, setWatchlistVideos] = useState<WatchlistVideoItem[]>([]);
-  const [filteredVideos, setFilteredVideos] = useState<WatchlistVideoItem[]>([]);
 
   // 指標選択
   const [selectedMetric, setSelectedMetric] = useState<MetricType>('play_count_increase');
@@ -109,6 +108,9 @@ export default function VideoWatchlistPage() {
   // トレンドデータ
   const [trendData, setTrendData] = useState<VideoTrendData[]>([]);
   const [selectedVideoId, setSelectedVideoId] = useState<string | null>(null);
+  const [isTrendLoading, setIsTrendLoading] = useState(false);
+  const [trendError, setTrendError] = useState<string | null>(null);
+  const [lastTrendRangeKey, setLastTrendRangeKey] = useState<string | null>(null);
   
   const { toast } = useToast();
   
@@ -149,110 +151,224 @@ export default function VideoWatchlistPage() {
 
   // データを取得するuseEffect
   useEffect(() => {
+
     if (!dataLoaded || userSelectedDate) {
+
       const loadWatchlistVideos = async () => {
+
         try {
+
           setIsLoading(true);
+
           setError(null);
+
           
-          // 日付形式をYYYY-MM-DDに変換
+
+          // 日付範囲をYYYY-MM-DDに変換
+
           let startDateStr = '';
+
           let endDateStr = '';
+
           
+
           if (dateRange) {
+
             startDateStr = dateRange.start.toISOString().split('T')[0];
+
             endDateStr = dateRange.end.toISOString().split('T')[0];
+
           }
 
-          const [watchlistResult, trendResult] = await Promise.allSettled([
-            getVideoWatchlist(
-              dateRange ? startDateStr : undefined, 
-              dateRange ? endDateStr : undefined
-            ),
-            getVideoWatchlistTrends(
-              dateRange ? startDateStr : undefined, 
-              dateRange ? endDateStr : undefined
-            )
-          ]);
+
+
+          const result = await getVideoWatchlist(
+
+            dateRange ? startDateStr : undefined, 
+
+            dateRange ? endDateStr : undefined
+
+          );
+
           
-          if (watchlistResult.status === 'fulfilled') {
-            const result = watchlistResult.value;
-            console.log('API応答結果:', result);
+
+          if (result.success) {
+
+            console.log('取得したデータ数:', result.data?.length || 0);
+
+            console.log('最初のデータ:', result.data?.[0] || 'データなし');
+
             
-            if (result.success) {
-              console.log('取得したデータ数:', result.data?.length || 0);
-              console.log('最初のデータ:', result.data?.[0] || 'データなし');
+
+            if (result.data && Array.isArray(result.data) && result.data.length > 0) {
+
+              setWatchlistVideos(result.data);
+
               
-              if (result.data && Array.isArray(result.data) && result.data.length > 0) {
-                setWatchlistVideos(result.data);
-                setFilteredVideos(result.data);
+
+              if (result.period) {
+
+                setPeriodInfo(result.period);
+
                 
-                if (result.period) {
-                  setPeriodInfo(result.period);
-                  
-                  if (!userSelectedDate) {
-                    setDateRange({
-                      start: new Date(result.period.start_date),
-                      end: new Date(result.period.end_date)
-                    });
-                    setTempDateRange({
-                      start: new Date(result.period.start_date),
-                      end: new Date(result.period.end_date)
-                    });
-                  }
-                } else {
-                  setPeriodInfo({
-                    start_date: startDateStr,
-                    end_date: endDateStr
+
+                if (!userSelectedDate) {
+
+                  setDateRange({
+
+                    start: new Date(result.period.start_date),
+
+                    end: new Date(result.period.end_date)
+
                   });
+
+                  setTempDateRange({
+
+                    start: new Date(result.period.start_date),
+
+                    end: new Date(result.period.end_date)
+
+                  });
+
                 }
-                
-                setDataLoaded(true);
-                setUserSelectedDate(false);
+
               } else {
-                console.warn('APIからデータが返されましたが、データが空です');
-                setWatchlistVideos([]);
-                setFilteredVideos([]);
+
                 setPeriodInfo({
+
                   start_date: startDateStr,
+
                   end_date: endDateStr
+
                 });
-                setTrendData([]);
+
               }
+
+              
+
+              setDataLoaded(true);
+
+              setUserSelectedDate(false);
+
+              setTrendData([]);
+
+              setTrendError(null);
+
+              setLastTrendRangeKey(null);
+
             } else {
-              console.error('APIエラー:', result.error);
-              setError('動画ウォッチリストの取得に失敗しました');
+
+              console.warn('APIからデータが返されましたが、データが空です');
+
+              setWatchlistVideos([]);
+
+              setPeriodInfo({
+
+                start_date: startDateStr,
+
+                end_date: endDateStr
+
+              });
+
+              setTrendData([]);
+
+              setLastTrendRangeKey(null);
+
             }
+
           } else {
-            console.error("API呼び出しエラー:", watchlistResult.reason);
+
+            console.error('APIエラー:', result.error);
+
             setError('動画ウォッチリストの取得に失敗しました');
+
           }
 
-          if (trendResult.status === 'fulfilled') {
-            if (trendResult.value.success && trendResult.value.data) {
-              setTrendData(trendResult.value.data);
-            }
-          } else {
-            console.error('トレンドデータ取得エラー:', trendResult.reason);
-          }
         } catch (err) {
+
           console.error("API呼び出しエラー:", err);
+
           setError('動画ウォッチリストの取得に失敗しました');
+
         } finally {
+
           setIsLoading(false);
+
         }
+
       };
 
+
+
       loadWatchlistVideos();
+
     }
+
   }, [dataLoaded, userSelectedDate, dateRange]);
+
+
+
   
-  // // ジャンルフィルタリングを適用するuseEffectを単純化
-  // useEffect(() => {
-  //   // ハッシュタグでフィルタリングしない - すべてのデータを表示
-  //   console.log('全データ表示:', watchlistVideos.length);
-  //   setFilteredVideos(watchlistVideos);
-  // }, [watchlistVideos]);
+  const filteredVideos = useMemo(() => watchlistVideos, [watchlistVideos]);
+
+  useEffect(() => {
+    if (activeTab !== 'ranking' || !dataLoaded || userSelectedDate) {
+      return;
+    }
+
+    if (watchlistVideos.length === 0) {
+              setTrendData([]);
+              setTrendError(null);
+              setLastTrendRangeKey(null);
+      return;
+    }
+
+    let startDateStr = '';
+    let endDateStr = '';
+
+    if (dateRange) {
+      startDateStr = dateRange.start.toISOString().split('T')[0];
+      endDateStr = dateRange.end.toISOString().split('T')[0];
+    }
+
+    const rangeKey = `${startDateStr || 'default'}_${endDateStr || 'default'}`;
+
+    if (lastTrendRangeKey === rangeKey && trendData.length > 0) {
+      return;
+    }
+
+    const fetchTrends = async () => {
+      try {
+        setIsTrendLoading(true);
+        setTrendError(null);
+
+        const response = await getVideoWatchlistTrends(
+          dateRange ? startDateStr : undefined,
+          dateRange ? endDateStr : undefined
+        );
+
+        if (response.success) {
+          setTrendData(response.data || []);
+          setLastTrendRangeKey(rangeKey);
+        } else {
+          setTrendData([]);
+          setTrendError('トレンドデータの取得に失敗しました');
+          setLastTrendRangeKey(null);
+        }
+      } catch (error) {
+        console.error('トレンドデータ取得エラー:', error);
+        setTrendData([]);
+        setTrendError('トレンドデータの取得に失敗しました');
+        setLastTrendRangeKey(null);
+      } finally {
+        setIsTrendLoading(false);
+      }
+    };
+
+    fetchTrends();
+  }, [activeTab, dateRange, dataLoaded, userSelectedDate, lastTrendRangeKey, trendData.length, watchlistVideos.length]);
+
+
 
   const handleDateRangeChange = (newRange: { start: Date; end: Date }) => {
     setTempDateRange(newRange);
@@ -705,11 +821,138 @@ export default function VideoWatchlistPage() {
                     {/* 推移グラフ */}
                     <div className="h-[400px] border border-gray-200 dark:border-gray-800 rounded-md p-4">
                       <div className="h-full flex flex-col">
-                        <div className="mb-2">
-                          <h3 className="text-sm font-medium">
-                            上位10動画の{getMetricDisplayName(selectedMetric)}推移
-                          </h3>
+                        <div className="mb-2">
+                          <h3 className="text-sm font-medium">
+                            ���10�����{getMetricDisplayName(selectedMetric)}����
+                          </h3>
+                        </div>
+                        <div className="flex-grow">
+
+                          {isTrendLoading ? (
+
+                            <div className="h-full flex items-center justify-center">
+
+                              <Skeleton className="h-[200px] w-full" />
+
+                            </div>
+
+                          ) : trendError ? (
+
+                            <div className="h-full flex items-center justify-center">
+
+                              <p className="text-sm text-red-400">{trendError}</p>
+
+                            </div>
+
+                          ) : trendData.length > 0 ? (
+
+                            <ResponsiveContainer width="100%" height="100%">
+
+                              <LineChart
+
+                                data={formattedGraphData}
+
+                                margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+
+                              >
+
+                                <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+
+                                <XAxis 
+
+                                  dataKey="date" 
+
+                                  tickFormatter={(value) => value.split('-').slice(1).join('/')}
+
+                                />
+
+                                <YAxis />
+
+                                <Tooltip 
+
+                                  labelFormatter={(value) => `���t: ${value}`}
+
+                                  formatter={(value, name) => [formatNumber(Number(value)), name]}
+
+                                />
+
+                                <Legend />
+
+                                {topVideosTrends.map((videoTrend, index) => {
+
+                                  // �N�₩�Ō������₷��10�F�̃J���[�p���b�g
+
+                                  const colors = [
+
+                                    '#FF3B30',
+
+                                    '#34C759',
+
+                                    '#007AFF',
+
+                                    '#FF9500',
+
+                                    '#5856D6',
+
+                                    '#FF2D55',
+
+                                    '#00C7BE',
+
+                                    '#AF52DE',
+
+                                    '#FFCC00',
+
+                                    '#8E8E93'
+
+                                  ];
+
+                                  const color = colors[index % colors.length];
+
+                                  const rankLabel = `${index + 1}��`;
+
+                                  
+
+                                  return (
+
+                                    <Line 
+
+                                      key={videoTrend.video_id}
+
+                                      type="monotone" 
+
+                                      dataKey={rankLabel}
+
+                                      stroke={color}
+
+                                      name={rankLabel}
+
+                                      dot={{ r: 3 }}
+
+                                      activeDot={{ r: 6 }}
+
+                                    />
+
+                                  );
+
+                                })}
+
+                              </LineChart>
+
+                            </ResponsiveContainer>
+
+                          ) : (
+
+                            <div className="h-full flex items-center justify-center">
+
+                              <p className="text-gray-400">�g�����h�f�[�^�����p�ł��܂���</p>
+
+                            </div>
+
+                          )}
+
                         </div>
+
+
                         <div className="flex-grow">
                           {trendData.length > 0 ? (
                             <ResponsiveContainer width="100%" height="100%">


### PR DESCRIPTION
ウォッチリストのトレンド取得をタブ切り替え時に遅延実行するよう分離し、ビルドエラーを解消しつつ表示レスポンスを改善しました。
ラインチャートにはローディング／エラー表示を追加し、期間変更時の表示崩れを防止しています。
アカウントウォッチリストのタイプフィルタは一旦コメントアウトし、従来の挙動に戻しました。